### PR TITLE
OpenJobsCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Buildkite > RunningBuildsCount
 Buildkite > RunningJobsCount
 Buildkite > ScheduledBuildsCount
 Buildkite > ScheduledJobsCount
+Buildkite > UnfinishedJobsCount
 Buildkite > IdleAgentsCount
 Buildkite > BusyAgentsCount
 Buildkite > TotalAgentsCount
@@ -39,6 +40,7 @@ Buildkite > (Queue) > RunningBuildsCount
 Buildkite > (Queue) > RunningJobsCount
 Buildkite > (Queue) > ScheduledBuildsCount
 Buildkite > (Queue) > ScheduledJobsCount
+Buildkite > (Queue) > UnfinishedJobsCount
 Buildkite > (Queue) > IdleAgentsCount
 Buildkite > (Queue) > BusyAgentsCount
 Buildkite > (Queue) > TotalAgentsCount
@@ -47,6 +49,7 @@ Buildkite > (Pipeline) > RunningBuildsCount
 Buildkite > (Pipeline) > RunningJobsCount
 Buildkite > (Pipeline) > ScheduledBuildsCount
 Buildkite > (Pipeline) > ScheduledJobsCount
+Buildkite > (Pipeline) > UnfinishedJobsCount
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ const (
 	runningJobsCount     = "RunningJobsCount"
 	scheduledBuildsCount = "ScheduledBuildsCount"
 	scheduledJobsCount   = "ScheduledJobsCount"
+	unfinishedJobsCount  = "UnfinishedJobsCount"
 	totalAgentCount      = "TotalAgentCount"
 	busyAgentCount       = "BusyAgentCount"
 	idleAgentCount       = "IdleAgentCount"
@@ -172,6 +173,7 @@ func newCounts() counts {
 		scheduledBuildsCount: 0,
 		runningJobsCount:     0,
 		scheduledJobsCount:   0,
+		unfinishedJobsCount:  0,
 	}
 }
 
@@ -266,14 +268,19 @@ func (r *result) addBuildAndJobMetrics(client *buildkite.Client, opts collectOpt
 					r.queues[queue(job)] = newCounts()
 				}
 
-				switch state {
-				case "running":
-					r.totals[runningJobsCount]++
-					r.queues[queue(job)][runningJobsCount]++
+				if state == "running" || state == "scheduled" {
+					switch state {
+					case "running":
+						r.totals[runningJobsCount]++
+						r.queues[queue(job)][runningJobsCount]++
 
-				case "scheduled":
-					r.totals[scheduledJobsCount]++
-					r.queues[queue(job)][scheduledJobsCount]++
+					case "scheduled":
+						r.totals[scheduledJobsCount]++
+						r.queues[queue(job)][scheduledJobsCount]++
+					}
+
+					r.totals[unfinishedJobsCount]++
+					r.queues[queue(job)][unfinishedJobsCount]++
 				}
 
 				buildQueues[queue(job)]++


### PR DESCRIPTION
We've got a bit of an issue with our ASG in EC2, its scaling policies are based on the buildkite-metrics cloudwatch data publisher. Scaling in is a bit of an issue though, because binding to ScheduledJobsCount can cause a downscale in the middle of a build, since there are no remaining ScheduledJobs. Binding on RunningJobsCount can cause the ASG to scale in before it can accept a job. It'd be nice to have a composite metric, say OpenJobsCount, which is comprised of RunningJobs and ScheduledJobs. Which is what I've added in this PR