### PR TITLE
Improve error logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func (r *result) addHistoricalMetrics(client *buildkite.Client, opts collectOpts
 		FinishedFrom: time.Now().UTC().Add(opts.Historical * -1),
 	})
 
-	return finishedBuilds.Pages(func(v interface{}, lastPage bool) bool {
+	return finishedBuilds.Pages(func(v interface{}) bool {
 		for _, queue := range uniqueQueues(v.([]buildkite.Build)) {
 			if _, ok := r.queues[queue]; !ok {
 				r.queues[queue] = newCounts()
@@ -230,7 +230,7 @@ func (r *result) addBuildAndJobMetrics(client *buildkite.Client, opts collectOpt
 		State: []string{"scheduled", "running"},
 	})
 
-	return currentBuilds.Pages(func(v interface{}, lastPage bool) bool {
+	return currentBuilds.Pages(func(v interface{}) bool {
 		for _, build := range v.([]buildkite.Build) {
 			// log.Printf("Adding build to stats (id=%q, pipeline=%q, branch=%q, state=%q)",
 			// 	*build.ID, *build.Pipeline.Name, *build.Branch, *build.State)
@@ -329,7 +329,7 @@ func (r *result) addAgentMetrics(client *buildkite.Client, opts collectOpts) err
 		r.queues[queue][totalAgentCount] = 0
 	}
 
-	err := p.Pages(func(v interface{}, lastPage bool) bool {
+	err := p.Pages(func(v interface{}) bool {
 		agents := v.([]buildkite.Agent)
 
 		for _, agent := range agents {
@@ -376,14 +376,14 @@ type pager struct {
 	lister func(page int) (v interface{}, nextPage int, err error)
 }
 
-func (p *pager) Pages(f func(v interface{}, lastPage bool) bool) error {
+func (p *pager) Pages(f func(v interface{}) bool) error {
 	page := 1
 	for {
 		val, nextPage, err := p.lister(page)
 		if err != nil {
 			return err
 		}
-		if !f(val, nextPage == 0) || nextPage == 0 {
+		if !f(val) || nextPage == 0 {
 			break
 		}
 		page = nextPage

--- a/main.go
+++ b/main.go
@@ -311,11 +311,10 @@ func (r *result) addAgentMetrics(client *buildkite.Client, opts collectOpts) err
 					Page: page,
 				},
 			})
-			log.Printf("Agents page %d has %d agents, next page is %d",
-				page,
-				len(agents),
-				resp.NextPage,
-			)
+			if err != nil {
+				return nil, 0, err
+			}
+			log.Printf("Agents page %d has %d agents, next page is %d", page, len(agents), resp.NextPage)
 			return agents, resp.NextPage, err
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -399,6 +399,9 @@ func listBuildsByOrg(builds *buildkite.BuildsService, orgSlug string, opts build
 				Page: page,
 			}
 			builds, resp, err := builds.ListByOrg(orgSlug, &opts)
+			if err != nil {
+				return nil, 0, err
+			}
 			log.Printf("Builds page %d has %d builds, next page is %d", page, len(builds), resp.NextPage)
 			return builds, resp.NextPage, err
 		},


### PR DESCRIPTION
We are seeing intermittent failures to collect metrics. When failures happen, our logs are showing the following nil pointer dereference error:

```
2016/09/15 05:29:39 Collecting running and scheduled build and job metrics
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x408126]
goroutine 1 [running]:
panic(0x847ba0, 0xc8200100a0)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
main.listBuildsByOrg.func1(0x1, 0x0, 0x0, 0xc82005d500, 0x0, 0x0)
        /go/src/github.com/buildkite/buildkite-metrics/main.go:402 +0x386
main.(*pager).Pages(0xc820024080, 0xc82004daa0, 0x0, 0x0)
        /go/src/github.com/buildkite/buildkite-metrics/main.go:383 +0x3c
main.(*result).addBuildAndJobMetrics(0xc8200b4b00, 0xc8200125f0, 0x7fffdefa7d10, 0x3, 0x0, 0x7fffdefa7d4b, 0xd, 0x0, 0x0)
        /go/src/github.com/buildkite/buildkite-metrics/main.go:303 +0x13c
main.collectResults(0xc8200125f0, 0x7fffdefa7d10, 0x3, 0x0, 0x7fffdefa7d4b, 0xd, 0x28, 0x0, 0x0)
        /go/src/github.com/buildkite/buildkite-metrics/main.go:116 +0x4ab
main.main.func1(0x0, 0x0)
        /go/src/github.com/buildkite/buildkite-metrics/main.go:66 +0x140
main.main()
        /go/src/github.com/buildkite/buildkite-metrics/main.go:82 +0x76f
```

We get a nil pointer dereference error because the code calling the buildkite API ignores errors which are returned. This change adds error handling for two cases where errors are ignored, so that we can report better error messages in the future.