### PR TITLE
Log fatal error when ListByOrg fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -399,6 +399,9 @@ func listBuildsByOrg(builds *buildkite.BuildsService, orgSlug string, opts build
 				Page: page,
 			}
 			builds, resp, err := builds.ListByOrg(orgSlug, &opts)
+			if err != nil {
+				log.Fatalf("list builds failed: %s", err)
+			}
 			log.Printf("Builds page %d has %d builds, next page is %d", page, len(builds), resp.NextPage)
 			return builds, resp.NextPage, err
 		},


### PR DESCRIPTION
Trying to run buildkite-metrics I get the following stack trace

```
2016/09/16 00:49:33 Collecting historical metrics
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x408126]

goroutine 1 [running]:
panic(0x847ba0, 0xc820010080)
       	/usr/local/go/src/runtime/panic.go:481 +0x3e6
main.listBuildsByOrg.func1(0x1, 0x0, 0x0, 0xc820057500, 0x0, 0x0)
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:402 +0x386
main.(*pager).Pages(0xc82001e090, 0xc82003fa58, 0x0, 0x0)
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:383 +0x3c
main.(*result).addHistoricalMetrics(0xc8200b4ac0, 0xc82000a690, 0x7ffd39565f25, 0x13, 0x4e94914f0000, 0x0, 0x0, 0x0, 0x0)
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:225 +0x1d3
main.collectResults(0xc82000a690, 0x7ffd39565f25, 0x13, 0x4e94914f0000, 0x0, 0x0, 0x28, 0x0, 0x0)
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:110 +0x325
main.main.func1(0x0, 0x0)
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:66 +0x140
main.main()
       	/go/src/github.com/buildkite/buildkite-metrics/main.go:82 +0x76f
```

I added some logging to try and diagnose it and the issue dissapeared so here's my fix ¯\_(ツ)_/¯
