### PR TITLE
Support the queue parameter and logs in lambda func

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Buildkite > (Pipeline) > ScheduledJobsCount
 Buildkite > (Pipeline) > UnfinishedJobsCount
 ```
 
+## AWS Lambda
+
+An AWS Lambda bundle is created and published as part of the build process.
+
+It's entrypoint is `handler.handle`, it requires a `python2.7` environment and makes use of the following env vars:
+
+ - BUILDKITE_ORG
+ - BUILDKITE_TOKEN
+ - BUILDKITE_BACKEND
+ - BUILDKITE_QUEUE
+
+Checkout https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/metrics.yml for examples of usage.
+
 ## License
 
 See [LICENSE.md](LICENSE.md) (MIT)

--- a/lambda.go
+++ b/lambda.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"log"
 	"os"
@@ -15,9 +14,6 @@ import (
 )
 
 func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
-	output := &bytes.Buffer{}
-	log.SetOutput(output)
-
 	org := os.Getenv("BUILDKITE_ORG")
 	token := os.Getenv("BUILDKITE_TOKEN")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
@@ -63,7 +59,7 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 	}
 
 	log.Printf("Finished in %s", time.Now().Sub(t))
-	return output.String(), nil
+	return "", nil
 }
 
 func init() {

--- a/lambda.go
+++ b/lambda.go
@@ -36,6 +36,10 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 		Historical: time.Hour * 24,
 	})
 
+	if queue != "" {
+		col.Queue = queue
+	}
+
 	var bk backend.Backend
 	if backendOpt == "statsd" {
 		bk, err = backend.NewStatsDBackend(os.Getenv("STATSD_HOST"), strings.ToLower(os.Getenv("STATSD_TAGS")) == "true")

--- a/lambda.go
+++ b/lambda.go
@@ -21,6 +21,7 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 	org := os.Getenv("BUILDKITE_ORG")
 	token := os.Getenv("BUILDKITE_TOKEN")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
+	queue := os.Getenv("BUILDKITE_QUEUE")
 
 	config, err := buildkite.NewTokenConfig(token, false)
 	if err != nil {


### PR DESCRIPTION
The 1.3.0 release lambda function logged all queues, this adds support for `BUILDKITE_QUEUE` and also for logging output.