### PR TITLE
Add retry for failed bk calls to lambda

### DIFF
--- a/lambda.go
+++ b/lambda.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -52,20 +53,43 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 		bk = &backend.CloudWatchBackend{}
 	}
 
-	res, err := col.Collect()
-	if err != nil {
-		return nil, err
+	return "", retry(time.Minute, func() error {
+		res, err := col.Collect()
+		if err != nil {
+			return err
+		}
+
+		res.Dump()
+
+		err = bk.Collect(res)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("Finished in %s", time.Now().Sub(t))
+		return nil
+	})
+}
+
+func retry(timeout time.Duration, callback func() error) (err error) {
+	t0 := time.Now()
+	i := 0
+	for {
+		i++
+
+		err = callback()
+		if err == nil {
+			return
+		}
+
+		delta := time.Now().Sub(t0)
+		if delta > timeout {
+			return fmt.Errorf("after %d attempts (during %s), last error: %s", i, delta, err)
+		}
+
+		time.Sleep(time.Second * 2)
+		log.Println("retrying after error:", err)
 	}
-
-	res.Dump()
-
-	err = bk.Collect(res)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Printf("Finished in %s", time.Now().Sub(t))
-	return "", nil
 }
 
 func init() {


### PR DESCRIPTION
I've noticed that we are seeing lots of connection errors in our lambdas. This adds some basic retry ability.