### PR TITLE
Reset prometheus queue gauges to prevent stale values persisting

### DIFF
--- a/backend/prometheus.go
+++ b/backend/prometheus.go
@@ -41,6 +41,12 @@ func newPrometheus() *Prometheus {
 }
 
 func (p *Prometheus) Collect(r *collector.Result) error {
+
+	// Clear the gauges to prevent stale values from persisting forever.
+	for _, gauge := range p.queues {
+		gauge.Reset()
+	}
+
 	for name, value := range r.Totals {
 		gauge, ok := p.totals[name]
 		if !ok {


### PR DESCRIPTION
There is currently a bug where if queues fail to report to the metrics collector the last known value for that queue will persist forever.

This can happen when an instance dies or is killed ungracefully, and causes incorrect metrics to be reported.

Feel free to close this if there is a more elegant solution but it is important for our use case that this bug is fixed and the metrics are correctly reported. #42 