### PR TITLE
Allow a custom cloudwatch dimension flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ By default metrics will be submitted to CloudWatch but the backend can be switch
 
 The Cloudwatch backend supports the following arguments:
 
-* `-cloudwatch-dimension`: A optional custom dimension in the form of `Key=Value`
+* `-cloudwatch-dimensions`: A optional custom dimension in the form of `Key=Value, Key=Value`
 
 The StatsD backend supports the following arguments:
 
@@ -93,7 +93,7 @@ It's entrypoint is `handler.handle`, it requires a `python2.7` environment and r
  - BUILDKITE_BACKEND
  - BUILDKITE_QUEUE
  - BUILDKITE_QUIET
- - BUILDKITE_CLOUDWATCH_DIMENSION
+ - BUILDKITE_CLOUDWATCH_DIMENSIONS
 
 Take a look at https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/metrics.yml for examples of usage.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Prometheus backend supports the following arguments
 
 1. The `-org` argument is no longer needed
 2. The `-token` argument is now an _Agent Registration Token_ — the same used in the Buildkite Agent configuration file, and found on the [Buildkite Agents page](https://buildkite.com/organizations/-/agents).
-3. Build and pipeline metrics have been removed, focusing on agents and jobs by queue for auto–scaling.  
+3. Build and pipeline metrics have been removed, focusing on agents and jobs by queue for auto–scaling.
    If you have a compelling reason to gather build or pipeline metrics please continue to use the [previous version](https://github.com/buildkite/buildkite-metrics/releases/tag/v2.1.0) or [open an issue](https://github.com/buildkite/buildkite-metrics/issues) with details.
 
 ## Development
@@ -83,12 +83,13 @@ When a queue is specified, only that queue's metrics are published.
 
 An AWS Lambda bundle is created and published as part of the build process.
 
-It's entrypoint is `handler.handle`, it requires a `python2.7` environment and makes use of the following env vars:
+It's entrypoint is `handler.handle`, it requires a `python2.7` environment and respects the following env vars:
 
  - BUILDKITE_TOKEN
  - BUILDKITE_BACKEND
  - BUILDKITE_QUEUE
  - BUILDKITE_QUIET
+ - BUILDKITE_CLOUDWATCH_DIMENSION
 
 Take a look at https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/metrics.yml for examples of usage.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ buildkite-metrics -token abc123... -queue my-queue
 
 By default metrics will be submitted to CloudWatch but the backend can be switched to StatsD or Prometheus using the command-line argument `-backend statsd` or `-backend prometheus` respectively.
 
-The StatsD backend supports the following arguments
+The Cloudwatch backend supports the following arguments:
+
+* `-cloudwatch-dimension`: A optional custom dimension in the form of `Key=Value`
+
+The StatsD backend supports the following arguments:
 
 * `-statsd-host HOST`: The StatsD host and port (defaults to `127.0.0.1:8125`).
 * `-statsd-tags`: Some StatsD servers like the agent provided by DataDog support tags. If specified, metrics will be tagged by `queue` otherwise metrics will include the queue name in the metric. Only enable this option if you know your StatsD server supports tags.

--- a/backend/cloudwatch.go
+++ b/backend/cloudwatch.go
@@ -16,6 +16,8 @@ type CloudWatchBackend struct {
 	dimension string
 }
 
+// NewCloudWatchBackend returns a new CloudWatchBackend with an
+// optional Dimension in the form of Key=Value
 func NewCloudWatchBackend(dimension string) *CloudWatchBackend {
 	return &CloudWatchBackend{dimension: dimension}
 }
@@ -25,6 +27,7 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 
 	var dimensionKey, dimensionValue string
 
+	// Support a custom dimension, needs to be parsed from Key=Value
 	if cb.dimension != "" {
 		dimensionParts := strings.SplitN(cb.dimension, "=", 2)
 		if len(dimensionParts) != 2 {
@@ -42,7 +45,7 @@ func (cb *CloudWatchBackend) Collect(r *collector.Result) error {
 	for name, c := range r.Queues {
 		dimensions := []*cloudwatch.Dimension{}
 
-		// Add a custom dimension if one is provided
+		// Add custom dimension if provided
 		if dimensionKey != "" {
 			dimensions = append(dimensions, &cloudwatch.Dimension{
 				Name: aws.String(dimensionKey), Value: aws.String(dimensionValue),

--- a/backend/cloudwatch_test.go
+++ b/backend/cloudwatch_test.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCloudWatchDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		s        string
+		expected []CloudWatchDimension
+	}{
+		{"", []CloudWatchDimension{}},
+		{" ", []CloudWatchDimension{}},
+		{"Key=Value", []CloudWatchDimension{{"Key", "Value"}}},
+		{"Key=Value,Another=Value", []CloudWatchDimension{{"Key", "Value"}, {"Another", "Value"}}},
+		{"Key=Value, Another=Value", []CloudWatchDimension{{"Key", "Value"}, {"Another", "Value"}}},
+		{"Key=Value, Another=Value ", []CloudWatchDimension{{"Key", "Value"}, {"Another", "Value"}}},
+	} {
+		t.Run(tc.s, func(t *testing.T) {
+			d, err := ParseCloudWatchDimensions(tc.s)
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(d, tc.expected) {
+				t.Errorf("Expected %s to parse to %#v, got %#v", tc.s, tc.expected, d)
+			}
+		})
+	}
+}

--- a/lambda.go
+++ b/lambda.go
@@ -19,6 +19,7 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
 	queue := os.Getenv("BUILDKITE_QUEUE")
+	clwDimension := os.Getenv("BUILDKITE_CLOUDWATCH_DIMENSION")
 	quietString := os.Getenv("BUILDKITE_QUIET")
 	quiet := quietString == "1" || quietString == "true"
 
@@ -32,11 +33,11 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 
 	c := collector.Collector{
 		UserAgent: userAgent,
-		Endpoint: "https://agent.buildkite.com/v3",
-		Token: token,
-		Queue: queue,
-		Quiet: quiet,
-		Debug: false,
+		Endpoint:  "https://agent.buildkite.com/v3",
+		Token:     token,
+		Queue:     queue,
+		Quiet:     quiet,
+		Debug:     false,
 		DebugHttp: false,
 	}
 
@@ -50,7 +51,7 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 			return nil, err
 		}
 	} else {
-		b = &backend.CloudWatchBackend{}
+		b = backend.NewCloudWatchBackend(clwDimension)
 	}
 
 	res, err := c.Collect()

--- a/lambda.go
+++ b/lambda.go
@@ -19,7 +19,7 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")
 	backendOpt := os.Getenv("BUILDKITE_BACKEND")
 	queue := os.Getenv("BUILDKITE_QUEUE")
-	clwDimension := os.Getenv("BUILDKITE_CLOUDWATCH_DIMENSION")
+	clwDimensions := os.Getenv("BUILDKITE_CLOUDWATCH_DIMENSIONS")
 	quietString := os.Getenv("BUILDKITE_QUIET")
 	quiet := quietString == "1" || quietString == "true"
 
@@ -51,7 +51,11 @@ func handle(evt json.RawMessage, ctx *runtime.Context) (interface{}, error) {
 			return nil, err
 		}
 	} else {
-		b = backend.NewCloudWatchBackend(clwDimension)
+		dimensions, err := backend.ParseCloudWatchDimensions(clwDimensions)
+		if err != nil {
+			return nil, err
+		}
+		b = backend.NewCloudWatchBackend(dimensions)
 	}
 
 	res, err := c.Collect()

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 		statsdTags     = flag.Bool("statsd-tags", false, "Whether your StatsD server supports tagging like Datadog")
 		prometheusAddr = flag.String("prometheus-addr", ":8080", "Prometheus metrics transport bind address")
 		prometheusPath = flag.String("prometheus-path", "/metrics", "Prometheus metrics transport path")
-		clwDimension   = flag.String("cloudwatch-dimension", "", "A  Cloudwatch dimension to index metrics under, in the form of Key=Value")
+		clwDimensions  = flag.String("cloudwatch-dimensions", "", "Cloudwatch dimensions to index metrics under, in the form of Key=Value, Other=Value")
 
 		// filters
 		queue = flag.String("queue", "", "Only include a specific queue")
@@ -53,7 +53,12 @@ func main() {
 
 	switch strings.ToLower(*backendOpt) {
 	case "cloudwatch":
-		bk = backend.NewCloudWatchBackend(*clwDimension)
+		dimensions, err := backend.ParseCloudWatchDimensions(*clwDimensions)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		bk = backend.NewCloudWatchBackend(dimensions)
 	case "statsd":
 		var err error
 		bk, err = backend.NewStatsDBackend(*statsdHost, *statsdTags)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		statsdTags     = flag.Bool("statsd-tags", false, "Whether your StatsD server supports tagging like Datadog")
 		prometheusAddr = flag.String("prometheus-addr", ":8080", "Prometheus metrics transport bind address")
 		prometheusPath = flag.String("prometheus-path", "/metrics", "Prometheus metrics transport path")
+		clwDimension   = flag.String("cloudwatch-dimension", "", "A  Cloudwatch dimension to index metrics under, in the form of Key=Value")
 
 		// filters
 		queue = flag.String("queue", "", "Only include a specific queue")
@@ -52,7 +53,7 @@ func main() {
 
 	switch strings.ToLower(*backendOpt) {
 	case "cloudwatch":
-		bk = backend.NewCloudWatchBackend()
+		bk = backend.NewCloudWatchBackend(*clwDimension)
 	case "statsd":
 		var err error
 		bk, err = backend.NewStatsDBackend(*statsdHost, *statsdTags)
@@ -78,11 +79,11 @@ func main() {
 
 	c := collector.Collector{
 		UserAgent: userAgent,
-		Endpoint: *endpoint,
-		Token: *token,
-		Queue: *queue,
-		Quiet: *quiet,
-		Debug: *debug,
+		Endpoint:  *endpoint,
+		Token:     *token,
+		Queue:     *queue,
+		Quiet:     *quiet,
+		Debug:     *debug,
 		DebugHttp: *debugHttp,
 	}
 


### PR DESCRIPTION
This allows a custom dimension to be added to Cloudwatch metrics, for instance `TeamName`, or `StackName` or `AccountID`. 

Related to https://github.com/buildkite/elastic-ci-stack-for-aws/issues/452.